### PR TITLE
Fix clock range rounding

### DIFF
--- a/client/src/components/TrayLayout/OnlineChart.util.test.ts
+++ b/client/src/components/TrayLayout/OnlineChart.util.test.ts
@@ -731,6 +731,20 @@ test('isLessThanHours returns correctly', () => {
     ).not.toBeTruthy();
 });
 
+describe('roundTo', () => {
+    it('does not change hour when already aligned to 3 hour boundary', async () => {
+        const { roundTo } = await import('./OnlineChart.util');
+        const dt = DateTime.fromISO('2021-06-19T12:10:00');
+        expect(roundTo(dt).hour).toBe(12);
+    });
+
+    it('rounds up to the next 3 hour boundary', async () => {
+        const { roundTo } = await import('./OnlineChart.util');
+        const dt = DateTime.fromISO('2021-06-19T13:00:00');
+        expect(roundTo(dt).hour).toBe(15);
+    });
+});
+
 export // Use an empty export to please Babel's single file emit.
 // https://github.com/Microsoft/TypeScript/issues/15230
  {};

--- a/client/src/components/TrayLayout/OnlineChart.util.ts
+++ b/client/src/components/TrayLayout/OnlineChart.util.ts
@@ -13,10 +13,14 @@ const clampItem =
     };
 
 export const roundTo = (start: DateTime) => {
-    const roundToMin = 3;
-    const remainder = roundToMin - (start.hour % roundToMin);
+    const roundToHours = 3;
+    const remainder = start.hour % roundToHours;
 
-    return start.plus({ hours: remainder });
+    if (remainder === 0) {
+        return start;
+    }
+
+    return start.plus({ hours: roundToHours - remainder });
 };
 
 export enum CLOCK_MODE {


### PR DESCRIPTION
## Summary
- fix rounding to nearest 3‑hour boundary
- add tests for `roundTo`

## Testing
- `npm test` (fails: vitest not found)
- `npm test` in `electron` (fails: vitest not found)

------
https://chatgpt.com/codex/tasks/task_e_68461bba371483289f2c2506b48c9d12