### PR TITLE
Implement secure login with code verification

### DIFF
--- a/client/src/AuthContext.tsx
+++ b/client/src/AuthContext.tsx
@@ -1,0 +1,48 @@
+import { createContext, useCallback, useEffect, useState } from 'react';
+import { requestCode as apiRequestCode, verifyCode as apiVerifyCode } from './services/auth.api';
+
+type AuthContextType = {
+    email: string | null;
+    requestCode: (email: string) => Promise<void>;
+    verifyCode: (email: string, code: string) => Promise<void>;
+    logout: () => void;
+};
+
+export const AuthContext = createContext<AuthContextType>({
+    email: null,
+    requestCode: async () => {},
+    verifyCode: async () => {},
+    logout: () => {},
+});
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+    const [email, setEmail] = useState<string | null>(() => localStorage.getItem('userEmail'));
+
+    useEffect(() => {
+        if (email) {
+            window.electronBridge
+                ?.invokeIpc('getMacAddress')
+                .then((mac) => window.electronBridge?.invokeIpc('setAuthInfo', { email, macAddress: mac }));
+        }
+    }, [email]);
+
+    const requestCode = useCallback(async (e: string) => {
+        await apiRequestCode(e);
+    }, []);
+
+    const verifyCode = useCallback(async (e: string, c: string) => {
+        await apiVerifyCode(e, c);
+        setEmail(e);
+        localStorage.setItem('userEmail', e);
+        const mac = await window.electronBridge?.invokeIpc('getMacAddress');
+        await window.electronBridge?.invokeIpc('setAuthInfo', { email: e, macAddress: mac });
+    }, []);
+
+    const logout = useCallback(() => {
+        setEmail(null);
+        localStorage.removeItem('userEmail');
+        window.electronBridge?.invokeIpc('setAuthInfo', { email: '', macAddress: '' });
+    }, []);
+
+    return <AuthContext.Provider value={{ email, requestCode, verifyCode, logout }}>{children}</AuthContext.Provider>;
+};

--- a/client/src/components/MainLayout/HeaderMenu.tsx
+++ b/client/src/components/MainLayout/HeaderMenu.tsx
@@ -6,23 +6,39 @@ import {
     AiOutlineSetting,
 } from 'react-icons/ai';
 
-import { Box } from '@chakra-ui/react';
+import { Box, Button, Menu, MenuButton, MenuItem as ChakraMenuItem, MenuList } from '@chakra-ui/react';
 import { Link as RouterLink } from 'react-router-dom';
+import { useContext } from 'react';
+import { AuthContext } from '../../AuthContext';
 import { ColorModeSwitcher } from '../ColorModeSwitcher';
 import { Header } from '../Header/Header';
 import { MenuItem } from '../Header/MenuItem';
 
-export const HeaderMenu = () => (
-    <Header brandLinkProps={{ to: '/app/timeline', as: RouterLink }}>
-        <MenuItem to="/app/timeline" icon={<AiOutlineBars />} title="Timeline" />
-        <MenuItem to="/app/summary" icon={<AiOutlineAreaChart />} title="Summary" />
-        <MenuItem to="/app/search" icon={<AiOutlineSearch />} title="Search" />
-        <MenuItem to="/app/settings" icon={<AiOutlineSetting />} title="Settings" />
-        <MenuItem to="/app/support" icon={<AiOutlineQuestionCircle />} title="Support" />
-        <Box flex="1" />
+export const HeaderMenu = () => {
+    const { email, logout } = useContext(AuthContext);
 
-        <Box>
-            <ColorModeSwitcher />
-        </Box>
-    </Header>
-);
+    return (
+        <Header brandLinkProps={{ to: '/app/timeline', as: RouterLink }}>
+            <MenuItem to="/app/timeline" icon={<AiOutlineBars />} title="Timeline" />
+            <MenuItem to="/app/summary" icon={<AiOutlineAreaChart />} title="Summary" />
+            <MenuItem to="/app/search" icon={<AiOutlineSearch />} title="Search" />
+            <MenuItem to="/app/settings" icon={<AiOutlineSetting />} title="Settings" />
+            <MenuItem to="/app/support" icon={<AiOutlineQuestionCircle />} title="Support" />
+            <Box flex="1" />
+
+            <Box>
+                <ColorModeSwitcher />
+            </Box>
+            {email && (
+                <Menu>
+                    <MenuButton as={Button} variant="ghost">
+                        {email}
+                    </MenuButton>
+                    <MenuList>
+                        <ChakraMenuItem onClick={logout}>Cerrar sesión</ChakraMenuItem>
+                    </MenuList>
+                </Menu>
+            )}
+        </Header>
+    );
+};

--- a/client/src/routes/LoginPage.tsx
+++ b/client/src/routes/LoginPage.tsx
@@ -1,0 +1,66 @@
+import { Box, Button, Flex, Input, Text, VStack } from '@chakra-ui/react';
+import { useContext, useState } from 'react';
+import { CardBox } from '../components/CardBox';
+import { AuthContext } from '../AuthContext';
+
+const allowedDomains = ['linktic.com', '3tcapital.co', 'wimbu.com'];
+
+export function LoginPage() {
+    const { requestCode, verifyCode } = useContext(AuthContext);
+    const [email, setEmail] = useState('');
+    const [code, setCode] = useState('');
+    const [error, setError] = useState('');
+    const [step, setStep] = useState<'email' | 'code'>('email');
+    const [message, setMessage] = useState('');
+
+    const validateDomain = (value: string) => {
+        return allowedDomains.some((d) => value.endsWith(`@${d}`));
+    };
+
+    const sendCode = async () => {
+        if (!validateDomain(email)) {
+            setError('Dominio no autorizado.');
+            return;
+        }
+        try {
+            await requestCode(email);
+            setMessage('Código enviado.');
+            setStep('code');
+            setError('');
+        } catch (e) {
+            setError('Error enviando código');
+        }
+    };
+
+    const submitCode = async () => {
+        try {
+            await verifyCode(email, code);
+        } catch (e) {
+            setError('Código inválido');
+            return;
+        }
+    };
+
+    return (
+        <Flex p={4} justifyContent="center" alignItems="center" h="100vh">
+            <CardBox width={['100%', '400px']}>
+                <VStack spacing={3} alignItems="stretch">
+                    {step === 'email' && (
+                        <>
+                            <Input placeholder="Correo" value={email} onChange={(e) => setEmail(e.target.value)} />
+                            <Button onClick={sendCode}>Enviar</Button>
+                        </>
+                    )}
+                    {step === 'code' && (
+                        <>
+                            <Input placeholder="Código" value={code} onChange={(e) => setCode(e.target.value)} />
+                            <Button onClick={submitCode}>Validar</Button>
+                        </>
+                    )}
+                    {message && <Text color="green">{message}</Text>}
+                    {error && <Text color="red">{error}</Text>}
+                </VStack>
+            </CardBox>
+        </Flex>
+    );
+}

--- a/client/src/services/auth.api.ts
+++ b/client/src/services/auth.api.ts
@@ -1,0 +1,21 @@
+export async function requestCode(email: string): Promise<void> {
+    const res = await fetch('/auth/request-code', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+    });
+    if (!res.ok) {
+        throw new Error('Request code failed');
+    }
+}
+
+export async function verifyCode(email: string, code: string): Promise<void> {
+    const res = await fetch('/auth/verify-code', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, code }),
+    });
+    if (!res.ok) {
+        throw new Error('Invalid code');
+    }
+}


### PR DESCRIPTION
## Summary
- add AuthContext for authentication state
- implement a login page with email + verification code flow
- display authenticated user in header with logout option
- gate webhook logging until authentication is set and include user info
- expose IPC actions for getting MAC address and setting auth info

## Testing
- `pnpm --filter ./client test`
- `pnpm --filter ./electron test` *(fails: Electron failed to install correctly)*

------
https://chatgpt.com/codex/tasks/task_e_6851e866451483288261b50785ff2169