### PR TITLE
Use Linktic webhook URLs

### DIFF
--- a/client/src/services/auth.api.ts
+++ b/client/src/services/auth.api.ts
@@ -1,7 +1,7 @@
-const API_BASE = 'https://auto.linktic.com';
+import { REQUEST_CODE_URL, VERIFY_CODE_URL } from '../webhook.constants';
 
 export async function requestCode(email: string): Promise<void> {
-    const res = await fetch(`${API_BASE}/auth/request-code`, {
+    const res = await fetch(REQUEST_CODE_URL, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email }),
@@ -12,7 +12,7 @@ export async function requestCode(email: string): Promise<void> {
 }
 
 export async function verifyCode(email: string, code: string): Promise<void> {
-    const res = await fetch(`${API_BASE}/auth/verify-code`, {
+    const res = await fetch(VERIFY_CODE_URL, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, code }),

--- a/client/src/webhook.constants.ts
+++ b/client/src/webhook.constants.ts
@@ -1,0 +1,3 @@
+export const REQUEST_CODE_URL = 'https://auto.linktic.com/webhook/tockler/request-code';
+export const VERIFY_CODE_URL = 'https://auto.linktic.com/webhook/tockler/verify-code';
+export const LOG_ACTIVITY_URL = 'https://auto.linktic.com/webhook/tockler/log-activity';

--- a/electron/src/utils/webhookQueue.ts
+++ b/electron/src/utils/webhookQueue.ts
@@ -2,6 +2,7 @@ import Store from 'electron-store';
 import { machineId } from 'node-machine-id';
 import { logManager } from './log-manager';
 import { config } from './config';
+import { LOG_ACTIVITY_URL } from '../webhook.constants';
 
 export interface WebhookEvent {
     id: number;
@@ -10,7 +11,6 @@ export interface WebhookEvent {
     nextAttempt: number;
 }
 
-const WEBHOOK_URL = 'https://auto.linktic.com/webhook/tockler/log-activity';
 const BASE_BACKOFF_MS = 60 * 1000; // 1 minute
 const MAX_BACKOFF_MS = 60 * 60 * 1000; // 1 hour
 
@@ -59,7 +59,7 @@ class WebhookQueue {
                     email,
                     mac_address: this.machineId,
                 };
-                const res = await fetch(WEBHOOK_URL, {
+                const res = await fetch(LOG_ACTIVITY_URL, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify(payload),
@@ -84,4 +84,4 @@ class WebhookQueue {
 }
 
 export const webhookQueue = new WebhookQueue();
-export { WEBHOOK_URL };
+export { LOG_ACTIVITY_URL };

--- a/electron/src/webhook.constants.ts
+++ b/electron/src/webhook.constants.ts
@@ -1,0 +1,3 @@
+export const REQUEST_CODE_URL = 'https://auto.linktic.com/webhook/tockler/request-code';
+export const VERIFY_CODE_URL = 'https://auto.linktic.com/webhook/tockler/verify-code';
+export const LOG_ACTIVITY_URL = 'https://auto.linktic.com/webhook/tockler/log-activity';


### PR DESCRIPTION
## Summary
- add webhook constants in client and electron apps
- use webhook constants for auth and log activity

## Testing
- `pnpm --filter ./client test`
- `pnpm --filter ./electron test` *(fails: Electron failed to install)*

------
https://chatgpt.com/codex/tasks/task_e_68522fdcd06c8328a606d4829794bd76